### PR TITLE
Fix segmentation fault when invoking __callStatic()

### DIFF
--- a/tests/call-handler-invoked.phpt
+++ b/tests/call-handler-invoked.phpt
@@ -1,0 +1,27 @@
+--TEST--
+__callStatic is invoked
+--FILE--
+<?php
+
+register_primitive_type_handler('null', 'NullHandler');
+
+class NullValueException extends Exception {
+
+}
+
+class NullHandler {
+    public static function __callStatic($name, $args) {
+        throw new NullValueException('Calling '.$name.' on null');
+    }
+}
+
+$null= null;
+try {
+    $null->method();
+} catch (NullValueException $expected) {
+    echo "Caught expected NVE '", $expected->getMessage(), "'\n";
+}
+
+?>
+--EXPECTF--
+Caught expected NVE 'Calling method on null'


### PR DESCRIPTION
This pull request fixes a segmentation fault when invocations fall back to `__callStatic`:

``` php
class h {
  static function __callStatic($name, $args) { }
}

register_primitive_type_handler('null', 'h');
$x= null;
return $x->method();
```

The hack that `$this` is available in the primitive handler methods and points to the value the method is called on although they're actually static methods doesn't work here. See the comment in `zend_vm_def.h` in its `ZEND_VM_HELPER(zend_do_fcall_common_helper...)`: _An internal function assumes $this is present and won't check that. So PHP would crash by allowing the call_. Why the Zend Engine treats `__callStatic` as an _internal_ function is not 100% clear to me; an educated guess is that it's for performance reasons.
