### PR TITLE
Refactor: Handler instances self param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 php:
   - 5.4
+  - 5.6
 
 before_script:
   - phpize

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: php
 php:
   - 5.4
+  - 5.5
   - 5.6
 
 matrix:
     allow_failures:
         - php: 5.4
+        - php: 5.5
 
 before_script:
   - phpize

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ php:
   - 5.4
   - 5.6
 
+matrix:
+    allow_failures:
+        - php: 5.4
+
 before_script:
   - phpize
   - ./configure --enable-scalar-objects

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ Registering type handlers
 -------------------------
 
 Type handlers are registered through `register_primitive_type_handler`. The
-function takes a type name (like "string" or "array") and a class name. The
-class is defined just like any other PHP class. The only difference is that
-its `$this` variable won't be an object, but rather the primitive type that
-the class operates on:
+function takes a type name (like "string" or "array") and either a class name
+or an instance. The class is defined just like any other PHP class. 
+
+All methods are passed the primitive as their first argument:
 
 ```php
 <?php
 
 class StringHandler {
-    public function length() {
-        return strlen($this);
+    public function length($self) {
+        return strlen($self);
     }
 }
 
@@ -84,12 +84,5 @@ This extension has a number of limitations:
 
  * It is not possible to write `"str"->method()` or `[...]->method()` or `(...)->method()`. This
    is a restriction of the PHP parser that can not be changed through an extension.
- * Due to technical limitations, it is no longer possible to create *mutable* APIs for primitive
-   types in PHP 5.6 or higher. Modifying `$this` within the methods is not possible (or rather,
-   will have no effect, as you'd just be changing a copy).
- * Some features can not be used within the methods of the handler, because they rely on `$this`
-   being an object. Using these may result in a segmentation fault. The only such feature that
-   is currently known are array-style callbacks (`[$class, $method]` and `[$obj, $method]`).
-   However closures are explicitly guaranteed to work.
 
   [windows_dlls]: http://windows.php.net/downloads/pecl/snaps/scalar_objects/20130301/

--- a/handlers/string.php
+++ b/handlers/string.php
@@ -3,51 +3,51 @@
 namespace str;
 
 class Handler {
-    public function length() {
-        return strlen($this);
+    public function length($self) {
+        return strlen($self);
     }
 
     /*
      * Slicing methods
      */
 
-    public function slice($offset, $length = null) {
-        $offset = $this->prepareOffset($offset);
-        $length = $this->prepareLength($offset, $length);
+    public function slice($self, $offset, $length = null) {
+        $offset = $this->prepareOffset($self, $offset);
+        $length = $this->prepareLength($self, $offset, $length);
 
         if (0 === $length) {
             return '';
         }
 
-        return substr($this, $offset, $length);
+        return substr($self, $offset, $length);
     }
 
-    public function replaceSlice($replacement, $offset, $length = null) {
-        $offset = $this->prepareOffset($offset);
-        $length = $this->prepareLength($offset, $length);
+    public function replaceSlice($self, $replacement, $offset, $length = null) {
+        $offset = $this->prepareOffset($self, $offset);
+        $length = $this->prepareLength($self, $offset, $length);
 
-        return substr_replace($this, $replacement, $offset, $length);
+        return substr_replace($self, $replacement, $offset, $length);
     }
 
     /*
      * Search methods
      */
 
-    public function indexOf($string, $offset = 0) {
-        $offset = $this->prepareOffset($offset);
+    public function indexOf($self, $string, $offset = 0) {
+        $offset = $this->prepareOffset($self, $offset);
 
         if ('' === $string) {
             return $offset;
         }
 
-        return strpos($this, $string, $offset);
+        return strpos($self, $string, $offset);
     }
 
-    public function lastIndexOf($string, $offset = null) {
+    public function lastIndexOf($self, $string, $offset = null) {
         if (null === $offset) {
-            $offset = $this->length();
+            $offset = $this->length($self);
         } else {
-            $offset = $this->prepareOffset($offset);
+            $offset = $this->prepareOffset($self, $offset);
         }
 
         if ('' === $string) {
@@ -56,30 +56,30 @@ class Handler {
 
         /* Converts $offset to a negative offset as strrpos has a different
          * behavior for positive offsets. */
-        return strrpos($this, $string, $offset - $this->length());
+        return strrpos($self, $string, $offset - $this->length($self));
     }
 
-    public function contains($string) {
-        return false !== $this->indexOf($string);
+    public function contains($self, $string) {
+        return false !== $this->indexOf($self, $string);
     }
 
-    public function startsWith($string) {
-        return 0 === $this->indexOf($string);
+    public function startsWith($self, $string) {
+        return 0 === $this->indexOf($self, $string);
     }
 
-    public function endsWith($string) {
-        return $this->lastIndexOf($string) === $this->length() - $string->length();
+    public function endsWith($self, $string) {
+        return $this->lastIndexOf($self, $string) === $this->length($self) - $string->length();
     }
 
-    public function count($string, $offset = 0, $length = null) {
-        $offset = $this->prepareOffset($offset);
-        $length = $this->prepareLength($offset, $length);
+    public function count($self, $string, $offset = 0, $length = null) {
+        $offset = $this->prepareOffset($self, $offset);
+        $length = $this->prepareLength($self, $offset, $length);
 
         if ('' === $string) {
             return $length + 1;
         }
 
-        return substr_count($this, $string, $offset, $length);
+        return substr_count($self, $string, $offset, $length);
     }
 
     /* This function has two prototypes:
@@ -87,7 +87,7 @@ class Handler {
      * replace(array(string $from => string $to) $replacements, int $limit = PHP_MAX_INT)
      * replace(string $from, string $to, int $limit = PHP_MAX_INT)
      */
-    public function replace($from, $to = null, $limit = null) {
+    public function replace($self, $from, $to = null, $limit = null) {
         if (is_array($from)) {
             $replacements = $from;
             $limit = $to;
@@ -97,71 +97,71 @@ class Handler {
             );
 
             if (null === $limit) {
-                return strtr($this, $from);
+                return strtr($self, $from);
             } else {
                 $this->verifyPositive($limit, 'Limit');
-                return $this->replaceWithLimit($this, $replacements, $limit);
+                return $this->replaceWithLimit($self, $replacements, $limit);
             }
         } else {
             $this->verifyNotEmptyString($from, 'From string');
 
             if (null === $limit) {
-                return str_replace($from, $to, $this);
+                return str_replace($from, $to, $self);
             } else {
                 $this->verifyPositive($limit, 'Limit');
-                return $this->replaceWithLimit($this, [$from => $to], $limit);
+                return $this->replaceWithLimit($self, [$from => $to], $limit);
             }
         }
     }
 
-    public function split($separator, $limit = PHP_INT_MAX) {
-        return explode($separator, $this, $limit);
+    public function split($self, $separator, $limit = PHP_INT_MAX) {
+        return explode($separator, $self, $limit);
     }
 
-    public function chunk($chunkLength = 1) {
+    public function chunk($self, $chunkLength = 1) {
         $this->verifyPositive($chunkLength, 'Chunk length');
-        return str_split($this, $chunkLength);
+        return str_split($self, $chunkLength);
     }
 
-    public function repeat($times) {
+    public function repeat($self, $times) {
         $this->verifyNotNegative($times, 'Number of repetitions');
-        return str_repeat($this, $times);
+        return str_repeat($self, $times);
     }
 
-    public function reverse() {
-        return strrev($this);
+    public function reverse($self) {
+        return strrev($self);
     }
 
-    public function toLower() {
-        return strtolower($this);
+    public function toLower($self) {
+        return strtolower($self);
     }
 
-    public function toUpper() {
-        return strtoupper($this);
+    public function toUpper($self) {
+        return strtoupper($self);
     }
 
-    public function trim($characters = " \t\n\r\v\0") {
-        return trim($this, $characters);
+    public function trim($self, $characters = " \t\n\r\v\0") {
+        return trim($self, $characters);
     }
 
-    public function trimLeft($characters = " \t\n\r\v\0") {
-        return ltrim($this, $characters);
+    public function trimLeft($self, $characters = " \t\n\r\v\0") {
+        return ltrim($self, $characters);
     }
 
-    public function trimRight($characters = " \t\n\r\v\0") {
-        return rtrim($this, $characters);
+    public function trimRight($self, $characters = " \t\n\r\v\0") {
+        return rtrim($self, $characters);
     }
 
-    public function padLeft($length, $padString = " ") {
-        return str_pad($this, $length, $padString, STR_PAD_LEFT);
+    public function padLeft($self, $length, $padString = " ") {
+        return str_pad($self, $length, $padString, STR_PAD_LEFT);
     }
 
-    public function padRight($length, $padString = " ") {
-        return str_pad($this, $length, $padString, STR_PAD_RIGHT);
+    public function padRight($self, $length, $padString = " ") {
+        return str_pad($self, $length, $padString, STR_PAD_RIGHT);
     }
 
-    protected function prepareOffset($offset) {
-        $len = $this->length();
+    protected function prepareOffset($self, $offset) {
+        $len = $this->length($self);
         if ($offset < -$len || $offset > $len) {
             throw new \InvalidArgumentException('Offset must be in range [-len, len]');
         }
@@ -173,19 +173,19 @@ class Handler {
         return $offset;
     }
 
-    protected function prepareLength($offset, $length) {
+    protected function prepareLength($self, $offset, $length) {
         if (null === $length) {
-            return $this->length() - $offset;
+            return $this->length($self) - $offset;
         }
         
         if ($length < 0) {
-            $length += $this->length() - $offset;
+            $length += $this->length($self) - $offset;
 
             if ($length < 0) {
                 throw new \InvalidArgumentException('Length too small');
             }
         } else {
-            if ($offset + $length > $this->length()) {
+            if ($offset + $length > $this->length($self)) {
                 throw new \InvalidArgumentException('Length too large');
             }
         }

--- a/handlers/string.php
+++ b/handlers/string.php
@@ -98,7 +98,7 @@ class Handler {
 
             // strtr() with an empty replacements array will crash in some PHP versions
             if (empty($replacements)) {
-                return $this;
+                return $self;
             }
 
             if (null === $limit) {

--- a/handlers/string_concept_case_insensitive_view.php
+++ b/handlers/string_concept_case_insensitive_view.php
@@ -18,8 +18,8 @@
 namespace str;
 
 class HandlerWithCaseInsensitiveView extends Handler {
-    public function caseInsensitive() {
-        return new CaseInsensitiveView($this);
+    public function caseInsensitive($self) {
+        return new CaseInsensitiveView($self);
     }
 }
 

--- a/php_scalar_objects.h
+++ b/php_scalar_objects.h
@@ -21,10 +21,6 @@
 #ifndef PHP_SCALAR_OBJECTS_H
 #define PHP_SCALAR_OBJECTS_H
 
-#if ZEND_MODULE_API_NO < 20131226
-#error *** You need minimum PHP 5.6.0 to compile this extension
-#endif
-
 extern zend_module_entry scalar_objects_module_entry;
 #define phpext_scalar_objects_ptr &scalar_objects_module_entry
 

--- a/php_scalar_objects.h
+++ b/php_scalar_objects.h
@@ -21,6 +21,10 @@
 #ifndef PHP_SCALAR_OBJECTS_H
 #define PHP_SCALAR_OBJECTS_H
 
+#if ZEND_MODULE_API_NO < 20131226
+#error *** You need minimum PHP 5.6.0 to compile this extension
+#endif
+
 extern zend_module_entry scalar_objects_module_entry;
 #define phpext_scalar_objects_ptr &scalar_objects_module_entry
 

--- a/php_scalar_objects.h
+++ b/php_scalar_objects.h
@@ -46,7 +46,7 @@ ZEND_MINFO_FUNCTION(scalar_objects);
 #define SCALAR_OBJECTS_NUM_HANDLERS (SCALAR_OBJECTS_MAX_HANDLER + 1)
 
 ZEND_BEGIN_MODULE_GLOBALS(scalar_objects)
-	zend_class_entry *handlers[SCALAR_OBJECTS_NUM_HANDLERS];
+	zval *handlers[SCALAR_OBJECTS_NUM_HANDLERS];
 ZEND_END_MODULE_GLOBALS(scalar_objects)
 
 #ifdef ZTS

--- a/run-tests.php
+++ b/run-tests.php
@@ -579,7 +579,7 @@ if (isset($argc) && $argc > 1) {
 					if (!$valgrind_header) {
 						error("Valgrind returned no version info, cannot proceed.\nPlease check if Valgrind is installed.");
 					} else {
-						$valgrind_version = preg_replace("/valgrind-([0-9])\.([0-9])\.([0-9]+)([.-\w]+)?(\s+)/", '$1$2$3', $valgrind_header, 1, $replace_count);
+						$valgrind_version = preg_replace("/valgrind-([0-9])\.([0-9])\.([0-9]+)([.\-\w]+)?(\s+)/", '$1$2$3', $valgrind_header, 1, $replace_count);
 						if ($replace_count != 1 || !is_numeric($valgrind_version)) {
 							error("Valgrind returned invalid version info (\"$valgrind_header\"), cannot proceed.");
 						}

--- a/scalar_objects.c
+++ b/scalar_objects.c
@@ -68,7 +68,8 @@ ZEND_GET_MODULE(scalar_objects)
         ((zf)->common.arg_info && \
         (arg_num <= (zf)->common.num_args \
                 ? ((zf)->common.arg_info[arg_num-1].pass_by_reference & (ZEND_SEND_BY_REF|ZEND_SEND_PREFER_REF)) \
-                : ((zf)->common.fn_flags & (ZEND_ACC_PASS_REST_BY_REFERENCE|ZEND_ACC_PASS_REST_PREFER_REF))
+                : ((zf)->common.fn_flags & (ZEND_ACC_PASS_REST_BY_REFERENCE|ZEND_ACC_PASS_REST_PREFER_REF)) \
+	))
 #endif
 
 static zval *get_zval_ptr_safe(

--- a/scalar_objects.c
+++ b/scalar_objects.c
@@ -283,20 +283,10 @@ static int scalar_objects_method_call_handler(ZEND_OPCODE_HANDLER_ARGS)
         execute_data->call->fbc = fbc;
         execute_data->call->called_scope = ce;
         execute_data->call->is_ctor_call = 0;
-#endif
 
-#if ZEND_MODULE_API_NO < 20131226
-        zend_ptr_stack_3_push(&EG(arg_types_stack), execute_data->fbc, execute_data->object, execute_data->called_scope);
-
-        execute_data->fbc = fbc;
-        execute_data->called_scope = ce;
-        execute_data->object = obj;
-# ifdef ZEND_ENGINE_2_5
-	execute_data->call->object = obj;
-# endif
-#else
-	execute_data->call->num_additional_args = 1;
-	execute_data->call->object = handler;
+# ifdef ZEND_ENGINE_2_6
+        execute_data->call->object = handler;
+        execute_data->call->num_additional_args = 1;
 
         /* Pass $self */
         ZEND_VM_STACK_GROW_IF_NEEDED(1);
@@ -304,6 +294,15 @@ static int scalar_objects_method_call_handler(ZEND_OPCODE_HANDLER_ARGS)
                 Z_SET_ISREF_P(obj);
         }
         zend_vm_stack_push(obj TSRMLS_CC);
+# else
+	execute_data->call->object = obj;
+# endif
+#else
+        zend_ptr_stack_3_push(&EG(arg_types_stack), execute_data->fbc, execute_data->object, execute_data->called_scope);
+
+        execute_data->fbc = fbc;
+        execute_data->called_scope = ce;
+        execute_data->object = obj;
 #endif
 
 	FREE_OP(free_op2);

--- a/scalar_objects.c
+++ b/scalar_objects.c
@@ -388,7 +388,9 @@ ZEND_RSHUTDOWN_FUNCTION(scalar_objects)
 {
 	int i;
 	for (i = 0; i < SCALAR_OBJECTS_NUM_HANDLERS; i++) {
-		zval_dtor(SCALAR_OBJECTS_G(handlers)[i]);
+		if (SCALAR_OBJECTS_G(handlers)[i]) {
+			zval_dtor(SCALAR_OBJECTS_G(handlers)[i]);
+		}
 	}
 	return SUCCESS;
 }

--- a/scalar_objects.c
+++ b/scalar_objects.c
@@ -56,6 +56,14 @@ ZEND_GET_MODULE(scalar_objects)
         zval_ptr_dtor(&should_free.var);                                            \
     }
 
+#define CHECK_ARG_SEND_TYPE(zf, arg_num, m) \
+        ((zf)->common.arg_info && \
+        (arg_num <= (zf)->common.num_args \
+                ? ((zf)->common.arg_info[arg_num-1].pass_by_reference & (m)) \
+                : ((zf)->common.fn_flags & ZEND_ACC_VARIADIC) \
+                        ? ((zf)->common.arg_info[(zf)->common.num_args-1].pass_by_reference & (m)) : 0))
+
+
 static zval *get_zval_ptr_safe(
 	int op_type, const znode_op *node, const zend_execute_data *execute_data
 ) {
@@ -167,9 +175,9 @@ static int scalar_objects_method_call_handler(ZEND_OPCODE_HANDLER_ARGS)
 {
 	zend_op *opline = execute_data->opline;
 	zend_free_op free_op1, free_op2;
-	zval *obj, *method;
-	zend_class_entry *ce;
+	zval *obj, *method, *handler;
 	zend_function *fbc;
+	zend_class_entry *ce;
 
 	/* First we fetch the ops without refcount changes or errors. Then we check whether we want
 	 * to handle this opcode ourselves or fall back to the original opcode. Only once we know for
@@ -181,19 +189,18 @@ static int scalar_objects_method_call_handler(ZEND_OPCODE_HANDLER_ARGS)
 		return ZEND_USER_OPCODE_DISPATCH;
 	}
 
-	ce = SCALAR_OBJECTS_G(handlers)[Z_TYPE_P(obj)];
-	if (!ce) {
+	handler = SCALAR_OBJECTS_G(handlers)[Z_TYPE_P(obj)];
+	if (!handler) {
 		zend_error(E_ERROR, "Call to a member function %s() on a non-object", Z_STRVAL_P(method));
 	}
 
-	if (ce->get_static_method) {
-		fbc = ce->get_static_method(ce, Z_STRVAL_P(method), Z_STRLEN_P(method) TSRMLS_CC);
-	} else {
-		fbc = zend_std_get_static_method(
-			ce, Z_STRVAL_P(method), Z_STRLEN_P(method),
-			opline->op2_type == IS_CONST ? opline->op2.literal + 1 : NULL TSRMLS_CC
-		);
-	}
+	Z_ADDREF_P(handler);
+
+	ce = Z_OBJCE_P(handler);
+	fbc = Z_OBJ_HT_P(handler)->get_method(
+		&handler, Z_STRVAL_P(method), Z_STRLEN_P(method),
+		opline->op2_type == IS_CONST ? opline->op2.literal + 1 : NULL TSRMLS_CC
+	);
 
 	if (!fbc) {
 		zend_error(E_ERROR, "Call to undefined method %s::%s()", ce->name, Z_STRVAL_P(method));
@@ -212,35 +219,28 @@ static int scalar_objects_method_call_handler(ZEND_OPCODE_HANDLER_ARGS)
 	execute_data->call = execute_data->call_slots + opline->result.num;
 	execute_data->call->fbc = fbc;
 	execute_data->call->called_scope = ce;
-	execute_data->call->object = obj;
+	execute_data->call->object = handler;
 	execute_data->call->is_ctor_call = 0;
 # ifdef ZEND_ENGINE_2_6
-	execute_data->call->num_additional_args = 0;
+	execute_data->call->num_additional_args = 1;
 # endif
 #else
 	zend_ptr_stack_3_push(&EG(arg_types_stack), execute_data->fbc, execute_data->object, execute_data->called_scope);
 
 	execute_data->fbc = fbc;
 	execute_data->called_scope = ce;
-	execute_data->object = obj;
+	execute_data->object = handler;
 #endif
 
 	FREE_OP(free_op2);
 	FREE_OP_IF_VAR(free_op1);
 
-	execute_data->opline++;
-	return ZEND_USER_OPCODE_CONTINUE;
-}
-
-static int scalar_objects_declare_lambda_function_handler(ZEND_OPCODE_HANDLER_ARGS)
-{
-	zend_op *opline = execute_data->opline;
-	zval *this_ptr = (EG(This) && Z_TYPE_P(EG(This)) == IS_OBJECT) ? EG(This) : NULL;
-
-	zend_function *fn;
-	zend_hash_quick_find(EG(function_table), Z_STRVAL_P(opline->op1.zv), Z_STRLEN_P(opline->op1.zv), Z_HASH_P(opline->op1.zv), (void *) &fn);
-
-	zend_create_closure(&SO_EX_T(opline->result.var).tmp_var, fn, EG(scope), this_ptr TSRMLS_CC);
+	/* Pass $self */
+	ZEND_VM_STACK_GROW_IF_NEEDED(1);
+	if (CHECK_ARG_SEND_TYPE(fbc, 1, ZEND_SEND_BY_REF|ZEND_SEND_PREFER_REF)) {
+		Z_SET_ISREF_P(obj);
+	}
+	zend_vm_stack_push(obj TSRMLS_CC);
 
 	execute_data->opline++;
 	return ZEND_USER_OPCODE_CONTINUE;
@@ -273,9 +273,9 @@ ZEND_FUNCTION(register_primitive_type_handler) {
 	char *type_str;
 	int type_str_len;
 	int type;
-	zend_class_entry *ce = NULL;
+	zval *arg;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sC", &type_str, &type_str_len, &ce) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz", &type_str, &type_str_len, &arg) == FAILURE) {
 		return;
 	}
 
@@ -286,14 +286,62 @@ ZEND_FUNCTION(register_primitive_type_handler) {
 
 	if (SCALAR_OBJECTS_G(handlers)[type] != NULL) {
 		zend_error(E_WARNING, "Handler for type \"%s\" already exists, overriding", type_str);
+		zval_dtor(SCALAR_OBJECTS_G(handlers)[type]);
 	}
 
-	SCALAR_OBJECTS_G(handlers)[type] = ce;
+	if (arg->type == IS_STRING) {
+		zend_class_entry **pce;
+		zend_function *constructor;
+		zval *instance;
+
+		if (zend_lookup_class(Z_STRVAL_P(arg), Z_STRLEN_P(arg), &pce TSRMLS_CC) == FAILURE) {
+			zend_error(E_WARNING, "Class %s not found", Z_STRVAL_P(arg));
+			return;
+		}
+	        ALLOC_ZVAL(instance);
+		object_init_ex(instance, *pce);
+		INIT_PZVAL(instance);
+
+		if (Z_OBJ_HT_P(instance)->get_method == NULL) {
+			zend_error(E_WARNING, "Object does not support method calls");
+			zval_dtor(instance);
+			return;
+		}
+
+		/* Invoke constructor if existant */
+		constructor = Z_OBJ_HT_P(instance)->get_constructor(instance TSRMLS_CC);
+		if (constructor != NULL) {
+			zval *retval;
+			zend_call_method(
+				&instance, *pce,
+				&constructor, ZEND_CONSTRUCTOR_FUNC_NAME, sizeof(ZEND_CONSTRUCTOR_FUNC_NAME) - 1,
+				&retval,
+				0, NULL, NULL
+				TSRMLS_CC
+			);
+			if (retval != NULL) {
+				zval_dtor(retval);
+			}
+			if (EG(exception) != NULL) {
+				zval_dtor(instance);
+				return;
+			}
+		}
+		SCALAR_OBJECTS_G(handlers)[type] = instance;
+	} else if (arg->type == IS_OBJECT) {
+		ALLOC_ZVAL(SCALAR_OBJECTS_G(handlers)[type]);
+		*SCALAR_OBJECTS_G(handlers)[type] = *arg;
+		zval_copy_ctor(SCALAR_OBJECTS_G(handlers)[type]);
+		INIT_PZVAL(SCALAR_OBJECTS_G(handlers)[type]);
+	} else {
+		zend_error(E_WARNING, "Expecting either a string or an object, %s given", zend_zval_type_name(arg));
+		return;
+	}
 }
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_register_handler, 0, 0, 2)
 	ZEND_ARG_INFO(0, "type")
-	ZEND_ARG_INFO(0, "class")
+	ZEND_ARG_INFO(0, "arg")
 ZEND_END_ARG_INFO()
 
 const zend_function_entry scalar_objects_functions[] = {
@@ -312,7 +360,7 @@ zend_module_entry scalar_objects_module_entry = {
 	ZEND_RINIT(scalar_objects),	
 	ZEND_RSHUTDOWN(scalar_objects),
 	ZEND_MINFO(scalar_objects),
-	"0.1",
+	"0.2",
 	ZEND_MODULE_GLOBALS(scalar_objects),
 	NULL,
 	NULL,
@@ -322,8 +370,6 @@ zend_module_entry scalar_objects_module_entry = {
 
 ZEND_MINIT_FUNCTION(scalar_objects) {
 	zend_set_user_opcode_handler(ZEND_INIT_METHOD_CALL, scalar_objects_method_call_handler);
-	zend_set_user_opcode_handler(ZEND_DECLARE_LAMBDA_FUNCTION, scalar_objects_declare_lambda_function_handler);
-
 	return SUCCESS;
 }
 
@@ -334,13 +380,16 @@ ZEND_MSHUTDOWN_FUNCTION(scalar_objects)
 
 ZEND_RINIT_FUNCTION(scalar_objects)
 {
-	memset(SCALAR_OBJECTS_G(handlers), 0, SCALAR_OBJECTS_NUM_HANDLERS * sizeof(zend_class_entry *));
-
+	memset(SCALAR_OBJECTS_G(handlers), 0, SCALAR_OBJECTS_NUM_HANDLERS * sizeof(zval *));
 	return SUCCESS;
 }
 
 ZEND_RSHUTDOWN_FUNCTION(scalar_objects)
 {
+	int i;
+	for (i = 0; i < SCALAR_OBJECTS_NUM_HANDLERS; i++) {
+		zval_dtor(SCALAR_OBJECTS_G(handlers)[i]);
+	}
 	return SUCCESS;
 }
 

--- a/scalar_objects.c
+++ b/scalar_objects.c
@@ -56,7 +56,7 @@ ZEND_GET_MODULE(scalar_objects)
         zval_ptr_dtor(&should_free.var);                                            \
     }
 
-#if ZEND_MODULE_API_NO >= 20131227
+#ifdef ZEND_ENGINE_2_6 
 #define SHOULD_SEND_ARG_BY_REF(zf, arg_num) \
         ((zf)->common.arg_info && \
         (arg_num <= (zf)->common.num_args \

--- a/tests/basic-repeated.phpt
+++ b/tests/basic-repeated.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test basic functionality repeatedly
+--SKIPIF--
+<?php
+if (!extension_loaded('scalar_objects')) echo 'skip';
+?>
+--FILE--
+<?php
+
+class StringHandler {
+    public function length($self) {
+        return strlen($self);
+    }
+}
+
+register_primitive_type_handler('string', 'StringHandler');
+
+$string= 'Hello';
+for ($i= 0; $i < 10000; $i++) {
+    $string->length();
+}
+var_dump($string->length());
+var_dump($string);
+?>
+--EXPECT--
+int(5)
+string(5) "Hello"

--- a/tests/basic.phpt
+++ b/tests/basic.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test basic functionality
+--SKIPIF--
+<?php
+if (!extension_loaded('scalar_objects')) echo 'skip';
+?>
+--FILE--
+<?php
+
+class StringHandler {
+    public function length($self) {
+        return strlen($self);
+    }
+}
+
+register_primitive_type_handler('string', 'StringHandler');
+
+$string= 'Hello';
+var_dump($string->length());
+var_dump($string);
+?>
+--EXPECT--
+int(5)
+string(5) "Hello"

--- a/tests/call-non-null.phpt
+++ b/tests/call-non-null.phpt
@@ -18,9 +18,9 @@ $number= 1;
 $number->toString();
 echo "Alive\n";
 ?>
---EXPECT--
+--EXPECTF--
 array(1) {
   [0]=>
-  int(1)
+  %snt(1)
 }
 Alive

--- a/tests/call-non-null.phpt
+++ b/tests/call-non-null.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test __call gets invoked 
+--SKIPIF--
+<?php
+if (!extension_loaded('scalar_objects')) echo 'skip';
+?>
+--FILE--
+<?php
+class NumberHandler {
+    public function __call($name, $args) {
+        var_dump($args);
+    }
+}
+
+register_primitive_type_handler('int', 'NumberHandler');
+
+$number= 1;
+$number->toString();
+echo "Alive\n";
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  int(1)
+}
+Alive

--- a/tests/call.phpt
+++ b/tests/call.phpt
@@ -29,7 +29,7 @@ echo "Alive\n";
 --EXPECTF--
 array(1) {
   [0]=>
-  %sNULL
+  %sULL
 }
 Caught expected NVE 'Calling length()'
 Alive

--- a/tests/call.phpt
+++ b/tests/call.phpt
@@ -3,6 +3,7 @@ Test __call gets invoked
 --SKIPIF--
 <?php
 if (!extension_loaded('scalar_objects')) echo 'skip';
+if (version_compare(PHP_VERSION, '5.6.0-beta1', '<')) echo 'skip';
 ?>
 --FILE--
 <?php

--- a/tests/call.phpt
+++ b/tests/call.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Test __call gets invoked 
+--SKIPIF--
+<?php
+if (!extension_loaded('scalar_objects')) echo 'skip';
+?>
+--FILE--
+<?php
+class NullValueException extends Exception {
+}
+
+class NullHandler {
+    public function __call($name, $args) {
+        var_dump($args);
+        throw new NullValueException('Calling '.$name.'()'); 
+    }
+}
+
+register_primitive_type_handler('null', 'NullHandler');
+
+$null= null;
+try {
+  $null->length();
+} catch (NullValueException $e) {
+  echo "Caught expected NVE '", $e->getMessage(), "'\n";
+}
+echo "Alive\n";
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  NULL
+}
+Caught expected NVE 'Calling length()'
+Alive

--- a/tests/closure_this_binding.phpt
+++ b/tests/closure_this_binding.phpt
@@ -1,5 +1,5 @@
 --TEST--
-$this is not bound for closures in type handlers
+$this is bound for closures in type handlers
 --FILE--
 <?php
 
@@ -17,5 +17,5 @@ $array->method();
 
 ?>
 --EXPECTF--
-Notice: Undefined variable: this in %s on line %d
-NULL
+object(ArrayHandler)#%d (0) {
+}

--- a/tests/constructor-throws.phpt
+++ b/tests/constructor-throws.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Tests constructor which throws an exception
+--SKIPIF--
+<?php
+if (!extension_loaded('scalar_objects')) echo 'skip';
+?>
+--FILE--
+<?php
+
+class Handler {
+    public function __construct($arg= null) {
+        if (!$arg) {
+	    throw new Exception('Cannot be used without arguments');
+        }
+    }
+}
+
+try {
+    register_primitive_type_handler('null', 'Handler');
+} catch (Exception $e) {
+    echo "Caught expected exception '", $e->getMessage(), "'\n";
+}
+register_primitive_type_handler('null', new Handler(1));
+echo "OK\n";
+?>
+--EXPECT--
+Caught expected exception 'Cannot be used without arguments'
+OK

--- a/tests/constructor.phpt
+++ b/tests/constructor.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Tests constructor is invoked
+--SKIPIF--
+<?php
+if (!extension_loaded('scalar_objects')) echo 'skip';
+?>
+--FILE--
+<?php
+
+class StringHandler {
+    public function __construct() {
+        var_dump($this);
+    }
+}
+
+register_primitive_type_handler('string', 'StringHandler');
+?>
+--EXPECTF--
+object(StringHandler)#%d (0) {
+}
+

--- a/tests/modification_in_handler.phpt
+++ b/tests/modification_in_handler.phpt
@@ -3,16 +3,13 @@ Test modification of array inside handler
 --SKIPIF--
 <?php
 if (!extension_loaded('scalar_objects')) echo 'skip';
-
-/* Not supported for builds against PHP 5.6 or higher */
-if (version_compare(PHP_VERSION, '5.6.0-dev', '>=')) echo 'skip';
 ?>
 --FILE--
 <?php
 
 class ArrayHandler {
-    public function pop() {
-        return array_pop($this);
+    public function pop(&$self) {
+        return array_pop($self);
     }
 }
 

--- a/tests/nested.phpt
+++ b/tests/nested.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test nested functionality
+--SKIPIF--
+<?php
+if (!extension_loaded('scalar_objects')) echo 'skip';
+?>
+--FILE--
+<?php
+
+class StringHandler {
+    public function length($self) {
+        return strlen($self);
+    }
+
+    public function endsWith($self, $search) { 
+        return 0 == substr_compare($self, $search, $self->length() - $search->length());
+    }
+}
+
+register_primitive_type_handler('string', 'StringHandler');
+
+$string= 'Hello';
+var_dump($string->endsWith('lo'));
+?>
+--EXPECT--
+bool(true)

--- a/tests/object.phpt
+++ b/tests/object.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test using an object 
+--SKIPIF--
+<?php
+if (!extension_loaded('scalar_objects')) echo 'skip';
+?>
+--FILE--
+<?php
+
+class StringHandler {
+    protected $encoding;
+
+    public function __construct($encoding= 'utf-8') {
+         $this->encoding= $encoding;
+    }
+
+    public function length($self) {
+        return iconv_strlen($self, $this->encoding);
+    }
+}
+
+register_primitive_type_handler('string', new StringHandler());
+
+$string= 'Hällo';
+var_dump($string->length());
+var_dump($string);
+?>
+--EXPECT--
+int(5)
+string(6) "Hällo"

--- a/tests/this.phpt
+++ b/tests/this.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test that $this points to handler instance 
+--SKIPIF--
+<?php
+if (!extension_loaded('scalar_objects')) echo 'skip';
+?>
+--FILE--
+<?php
+
+class Handler {
+    public function invoke($self) { 
+        var_dump($self);
+	var_dump($this);
+    }
+}
+
+register_primitive_type_handler('string', 'Handler');
+
+$var= "Value";
+$var->invoke();
+?>
+--EXPECTF--
+string(5) "Value"
+object(Handler)#%d (0) {
+}

--- a/tests/use_passed_value.phpt
+++ b/tests/use_passed_value.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test using the passed value 
+--SKIPIF--
+<?php
+if (!extension_loaded('scalar_objects')) echo 'skip';
+?>
+--FILE--
+<?php
+
+class StringHandler {
+    public function concat($self, $other) {
+        return $self.$other;
+    }
+}
+
+register_primitive_type_handler('string', 'StringHandler');
+
+$string= 'Hello';
+var_dump($string->concat(' ')->concat('World'));
+?>
+--EXPECT--
+string(11) "Hello World"


### PR DESCRIPTION
This pull request refactors the API to pass the value the method is invoked on as first argument to handlers' methods instead of filling in `$this` with it. This way, we're able to overcome the limitation of not being able to modify the value in PHP >= 5.6.0 (making the `array_pop` example work once again) and gets rid of segmentation faults when PHP relies on `$this` being an object.

## Old
```php
class ArrayHandler {
    public function pop() {
        return array_pop($this);
    }
}
$array= [1, 2, 3];
var_dump($array->pop()); // 3
var_dump($array);        // [1, 2, 3]
```

## New 
```php
class ArrayHandler {
    public function pop(&$self) {
        return array_pop($self);
    }
}
$array= [1, 2, 3];
var_dump($array->pop()); // 3
var_dump($array);        // [1, 2]
```
